### PR TITLE
Use absolute URL for external link

### DIFF
--- a/FHIR-hackathon-2025/input/pagecontent/index.md
+++ b/FHIR-hackathon-2025/input/pagecontent/index.md
@@ -50,7 +50,7 @@ The event will be of value to individuals working in the healthcare industry and
 
 ### How to attend
 
-* Please use the attendee form published by [EHiN 2025](ehin.no) to secure your place on the hackathon.
+* Please use the attendee form published by [EHiN 2025](https://ehin.no/) to secure your place on the hackathon.
 * Attend the startup meeting the week before, monday 3rd of November from 0900-1100 (this will be a digital only meeting).
 * Make your preparations for the workshop.
 * Meet us at [X meeting point](https://maps.app.goo.gl/EcvP399Myg3NAuzr8) (EHIN venue) for the first Norwegian FHIR Hackathon 10th november 2025.


### PR DESCRIPTION
Without the protocol part the link is interpreted as a relative link, and there is no page at https://hl7norway.github.io/FHIR-hackathon-2025/currentbuild/ehin.no.