### PR TITLE
Use correct URL for Nordic tx server

### DIFF
--- a/FHIR-hackathon-2025/input/pagecontent/index.md
+++ b/FHIR-hackathon-2025/input/pagecontent/index.md
@@ -23,7 +23,7 @@ During the Norwegian FHIR Hackathon you can:
 * Implement and test FHIR interfaces for services with existing proprietary API's
   * Use-case: [Oversikt over kommunale tjenester API (OKT)](https://utviklerportal.nhn.no/informasjonstjenester/felles-journalloeft/okt-prototype/okt-api/openapi/okt-api-prototype)
 * Implement and test use of FHIR terminology services
-  * [Nordic terminology server](https://ontoserver.csiro.au/ui/about)
+  * [Nordic terminology server](https://tx-nordics.fhir.org/fhir/r4)
 * Write and publish documentation of FHIR API's by authoring and publishing a FHIR Implementation Guide
 
 > DISCLAIMER: The results from the FHIR Hackaton signifies no obligation from the API owner (e.g. NHN/CSIRO), to make changes to their published API-services or software.


### PR DESCRIPTION
Let's point to the right address that reveals the correct endpoint. This redirects to CSIRO's Ontoserver, with the right endpoint selected.